### PR TITLE
Added spec Filed and add support to disable ssl verify

### DIFF
--- a/signalfx-forwarder-app/README/sfx.conf.spec
+++ b/signalfx-forwarder-app/README/sfx.conf.spec
@@ -1,0 +1,7 @@
+[setupentity]
+ingest_url =
+* This is the ingest_url for Signal FX
+signalfx_realm =
+* This is the signalfx_realm for Signal FX
+ssl_verify = 
+* This is used for requests/urllib3 should verify your ssl or not.

--- a/signalfx-forwarder-app/app.manifest
+++ b/signalfx-forwarder-app/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "signalfx-forwarder-app",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "author": [
       {

--- a/signalfx-forwarder-app/bin/sfx_config.py
+++ b/signalfx-forwarder-app/bin/sfx_config.py
@@ -34,7 +34,7 @@ class ConfigApp(admin.MConfigHandler):
 
     def setup(self):
         if self.requestedAction == admin.ACTION_EDIT:
-            for arg in ["access_token", "signalfx_realm", "ingest_url"]:
+            for arg in ["access_token", "signalfx_realm", "ingest_url", "ssl_verify"]:
                 self.supportedArgs.addOptArg(arg)
 
     def handleList(self, conf_info):  # pylint:disable=invalid-name
@@ -80,6 +80,8 @@ class ConfigApp(admin.MConfigHandler):
         if not access_token_list:
             raise admin.ArgValidationException("required access token is missing")
         self.save_access_token(access_token_list[0])
+		
+		ssl_verify = data.pop("ssl_verify")
 
         # Since we are using a conf file to store parameters,
         # write them to the [SignalFxConfig] stanza

--- a/signalfx-forwarder-app/default/app.conf
+++ b/signalfx-forwarder-app/default/app.conf
@@ -14,7 +14,7 @@ label = signalfx-forwarder
 [launcher]
 author = SignalFx
 description = Forward data to SignalFx via a custom search command
-version = 1.0.1
+version = 1.0.2
 
 [package]
 id = signalfx-forwarder-app

--- a/signalfx-forwarder-app/default/setup.xml
+++ b/signalfx-forwarder-app/default/setup.xml
@@ -19,6 +19,10 @@
       <label>Access Token</label>
       <type>text</type>
     </input>
+	<input field="ssl_verify" endpoint="signalfx-forwarder/sfx_config" entity="setupentity">
+      <label>SSL Verify</label>
+      <type>bool</type>
+    </input>
 
 
   </block>

--- a/signalfx-forwarder-app/default/sfx.conf
+++ b/signalfx-forwarder-app/default/sfx.conf
@@ -1,3 +1,4 @@
 [setupentity]
 ingest_url =
 signalfx_realm =
+ssl_verify = 


### PR DESCRIPTION
I added the possibility to disable ssl verify for the certificate to post to signalfx cloud. 
This can be done through setup page.

Also added README/sfx.conf.spec as requested by splunk.