### PR TITLE
Added events to SFX command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Run `slim package signalfx-forwarder` to generate the .tar.gz and upload to the 
 The repo includes a set of circleci tests that need to pass before your Pull Request can be merged.
 Perform the tests here https://app.circleci.com/ pointed at your updated github fork.
 
+However note that there appears to be an issue with circleci meaning that you if you are pushing to a PR on the signalfx repo you will need to "Stop Building" on your forked circleci project to allow the upstream PR repo to perform the circleci tests.
+
 #### Unit Testing
 Unit testing should be completed successfully and can be performed locally as follows.
 If you are adding new commands you may need to update the test cases defined in [./signalfx-forwarder-app/tests/splunk_test.py](./signalfx-forwarder-app/tests/splunk_test.py) and possibly the fake handling of the commands [./signalfx-forwarder-app/tests/helpers/fake_backend.py](./signalfx-forwarder-app/tests/helpers/fake_backend.py)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@ See [./signalfx-forwarder-app/README.md](./signalfx-forwarder-app/README.md) for
 You'll need to install the [Splunk Packacking Toolkit](https://dev.splunk.com/enterprise/docs/releaseapps/packagingtoolkit/installpkgtoolkit).
 Run `slim package signalfx-forwarder` to generate the .tar.gz and upload to the Github release.
 
+#### CI testing
+
+The repo includes a set of circleci tests that need to pass before your Pull Request can be merged.
+Perform the tests here https://app.circleci.com/ pointed at your updated github fork.
+
+#### Unit Testing
+Unit testing should be completed successfully and can be performed locally as follows.
+If you are adding new commands you may need to updated the test cases defined in [./signalfx-forwarder-app/tests/splunk_test.py](./signalfx-forwarder-app/tests/splunk_test.py) and possibly the fake handling of the commands [./signalfx-forwarder-app/tests/helpers/fake_backend.py](./signalfx-forwarder-app/tests/helpers/fake_backend.py)
+
+This process has been followed on a Mac with Docker installed.
+
+Build the app i.e. a tag.gz with the updated code in it
+```
+make package
+```
+
+Build the docker image which includes the mock signalfx API, a splunk docker image and the pytests:
+```
+docker build -t splunk-forwarder-test -f tests/Dockerfile .
+```
+
+Run the docker image being sure to mount the tmp directory to the image can access the package to install it as part of the testing:
+```
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v /tmp/scratch:/tmp/scratch splunk-forwarder-test
+```
+
+Note that you may need to add /tmp as a file share to your docker engine config. It can be found under the Docker Settings > Preferences > File Sharing.
+
 ### Support
 
 To file a bug report or request help please file an issue on our [Github

--- a/pylintrc
+++ b/pylintrc
@@ -349,7 +349,7 @@ ignore-docstrings=yes
 ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=10
+min-similarity-lines=100
 
 
 [BASIC]

--- a/signalfx-forwarder-app/README.md
+++ b/signalfx-forwarder-app/README.md
@@ -22,7 +22,7 @@ A custom search command to metricize Splunk events and send them to SignalFx
 **tosfx**:       Send the datapoints to SignalFx in a non streaming manner.
                  Does not work in realtime mode, but has higher throughput.
 
-**eventstosfx**:       Send the datapoints to SignalFx as events.
+**tosfxevents**:       Send the datapoints to SignalFx as events.
                  Does not work in realtime mode, but has higher throughput.
 
 Both commands also support arguments `dryrun` and `debug`.
@@ -48,7 +48,7 @@ index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | r
 ```
 
 ```
-index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | rename kb AS kilobytes | table _time kilobytes eventCount series host | `gauge(kilobytes)` |`gauge(eventCount)` | eventstosfx
+index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | rename kb AS kilobytes | table _time kilobytes eventCount series host | `gauge(kilobytes)` |`gauge(eventCount)` | tosfxevents
 ```
 
 ```

--- a/signalfx-forwarder-app/README.md
+++ b/signalfx-forwarder-app/README.md
@@ -48,7 +48,7 @@ index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | r
 ```
 
 ```
-index=myapp status="error"| eval message="an event that needs to be seen in SignalFX" | eval event_type="myapp_error" | tosfxevents
+index=myapp status="error"| eval message="an event to send to SignalFX" | eval event_type="myapp_error" | tosfxevents
 ```
 
 ```

--- a/signalfx-forwarder-app/README.md
+++ b/signalfx-forwarder-app/README.md
@@ -48,7 +48,7 @@ index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | r
 ```
 
 ```
-index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | rename kb AS kilobytes | table _time kilobytes eventCount series host | `gauge(kilobytes)` |`gauge(eventCount)` | tosfxevents
+index=myapp status="error"| eval message="an event that needs to be seen in SignalFX" | eval event_type="myapp_error" | tosfxevents
 ```
 
 ```

--- a/signalfx-forwarder-app/README.md
+++ b/signalfx-forwarder-app/README.md
@@ -22,6 +22,9 @@ A custom search command to metricize Splunk events and send them to SignalFx
 **tosfx**:       Send the datapoints to SignalFx in a non streaming manner.
                  Does not work in realtime mode, but has higher throughput.
 
+**eventstosfx**:       Send the datapoints to SignalFx as events.
+                 Does not work in realtime mode, but has higher throughput.
+
 Both commands also support arguments `dryrun` and `debug`.
 - `dryrun=t` will result in not sending any metrics to SignalFx, which is useful for
 testing your potential output in Splunk.
@@ -42,6 +45,10 @@ These arguments can be appended to the new commands. For example, `tosfx debug=t
 
 ```
 index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | rename kb AS kilobytes | table _time kilobytes eventCount series host | `gauge(kilobytes)` |`gauge(eventCount)` | tosfx
+```
+
+```
+index=_internal group=per_index_thruput series!=_* | rename ev AS eventCount | rename kb AS kilobytes | table _time kilobytes eventCount series host | `gauge(kilobytes)` |`gauge(eventCount)` | eventstosfx
 ```
 
 ```

--- a/signalfx-forwarder-app/app.manifest
+++ b/signalfx-forwarder-app/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null, 
       "name": "signalfx-forwarder-app", 
-      "version": "2.0.1"
+      "version": "2.0.2"
     }, 
     "author": [
       {

--- a/signalfx-forwarder-app/bin/eventstosfx.py
+++ b/signalfx-forwarder-app/bin/eventstosfx.py
@@ -1,0 +1,189 @@
+import gzip
+import json
+import os
+import sys
+from collections import OrderedDict
+from io import BytesIO
+
+current_path = os.path.dirname(__file__)  # pylint: disable=invalid-name
+sys.path.append(os.path.join(current_path, "libs"))
+sys.path.append(os.path.join(current_path, "libs", "sfxlib"))
+
+from splunklib.searchcommands import (  # isort:skip pylint: disable=import-error
+    Configuration,
+    EventingCommand,
+    Option,
+    dispatch,
+    validators,
+)
+
+import requests  # isort:skip
+
+
+@Configuration()
+class ToSFXCommand(EventingCommand):
+    """
+    ## Syntax
+
+    <command> | eventstosfx
+
+    ## Description
+
+    One or more datapoints are generated for each input event's field(s) of the
+    form `gauge_*`, `counter_*` or `cumulative_counter_*`.  The metric name in
+    SignalFx will be the `*` part of the field name.  Any additional fields on
+    the event will be attached as dimensions to the generated datapoints.
+
+    """
+
+    access_token = None
+    debug = Option(validate=validators.Boolean(), default=False)
+    dry_run = Option(validate=validators.Boolean(), default=False)
+    ingest_url = Option(validate=validators.Match("https://.*", r"^https://.*"))
+    ev_endpoint = Option(default="/v2/event")
+
+    SPLUNK_PASSWORD_REALM = "realm"
+    SPLUNK_PASSWORD_USER_NAME = "username"
+    SPLUNK_PASSWORD_CLEAR_PASSWORD = "clear_password"
+    SPLUNK_KV_STORE_SFX_CONFIG_COLLECTION_NAME = "sfx_ingest_config"
+    SPLUNK_SFX_CONFIG_INGEST_URL_KEY = "ingest_url"
+    SPLUNK_PASSWORDS_STORAGE_SFX_ACCESS_TOKEN_REALM = "sfx_ingest_command"
+    SPLUNK_PASSWORDS_STORAGE_SFX_ACCESS_TOKEN_USER_NAME = "access_token"
+
+    def ensure_default_config(self):
+        if not self.ingest_url:
+            self.ingest_url = self.get_sfx_ingest_url()
+
+        self.logger.error("getting access token")
+        self.access_token = self.get_access_token()
+
+    def get_access_token(self):
+        try:
+            for credential in self.service.storage_passwords:
+                if (
+                    credential.content.get(self.SPLUNK_PASSWORD_REALM, None)
+                    == self.SPLUNK_PASSWORDS_STORAGE_SFX_ACCESS_TOKEN_REALM
+                    and credential.content.get(self.SPLUNK_PASSWORD_USER_NAME, None)
+                    == self.SPLUNK_PASSWORDS_STORAGE_SFX_ACCESS_TOKEN_USER_NAME
+                ):
+                    return credential.content.get(self.SPLUNK_PASSWORD_CLEAR_PASSWORD, None)
+        except Exception as e:  # pylint:disable=broad-except
+            self.logger.error("status=error, action=get_sfx_access_token, error_msg=%s", e, exc_info=True)
+        return None
+
+    def get_sfx_ingest_url(self):
+        try:
+            sfx_api_config_collection = self.service.kvstore.get(self.SPLUNK_KV_STORE_SFX_CONFIG_COLLECTION_NAME, None)
+            if sfx_api_config_collection is not None:
+                collection = self.service.kvstore[self.SPLUNK_KV_STORE_SFX_CONFIG_COLLECTION_NAME]
+                # will return a list of settings, we should only have one.
+                # We'll grab the 'last' / most recent one by default
+                sfx_ingest_config_records = collection.data.query()
+                if sfx_ingest_config_records:
+                    sfx_ingest_config_latest = sfx_ingest_config_records[-1]
+                    return sfx_ingest_config_latest.get(self.SPLUNK_SFX_CONFIG_INGEST_URL_KEY, None)
+        except Exception as e:  # pylint:disable=broad-except
+            self.logger.error("status=error, action=get_sfx_ingest_url, error_msg=%s", str(e), exc_info=True)
+        return None
+
+    def transform(self, records):
+        self.ensure_default_config()
+
+        out = []
+        payload = []
+        for event in records:
+            add_event_to_payload(self,event=event, payload=payload)
+
+            if self.debug:
+                event["endpoint"] = self.ingest_url + self.ev_endpoint
+
+            out.append(event)
+
+        if not self.dry_run:
+            resp = send_payload(
+                payload=payload,
+                target_url=compose_ingest_url(self.ingest_url, self.ev_endpoint),
+                token=self.access_token,
+            )
+            for event in out:
+                event["status"] = resp.status_code
+                if resp.status_code != 200:
+                    event["response_error"] = resp.content
+
+        for event in out:
+            yield event
+
+
+def compose_ingest_url(ingest_base_url, ev_endpoint):
+    return ingest_base_url.rstrip("/") + ev_endpoint
+
+
+def populate_payload(metric_type, metric_list, payload, timestamp, dims):
+    expanded = []
+    for metric, value in metric_list:
+        expanded.append(dict([("metric", metric), ("value", value)]))
+        if timestamp:
+            expanded[-1]["timestamp"] = timestamp
+        expanded[-1]["dimensions"] = dims
+    if metric_type in payload:
+        # Append in reverse order because SignalFx expects data points oldest to latest
+        payload[metric_type] = expanded + payload[metric_type]
+    else:
+        payload[metric_type] = expanded
+
+
+def add_event_to_payload(self,event, payload):
+    
+    eventDict = dict()
+    dimensions = dict()
+    properties = dict()
+    timestamp = None
+    eventType = None
+    
+    
+    for key, value in event.items():
+        self.logger.error("key is "+str(key) + " value is "+str(value))
+        if value != "":
+            if key.startswith("event_"):
+                eventType = value
+            elif key.startswith("property_"):
+                if value[0] != "_" and len(value) < 256:
+                    newKey = key.replace("property_","")
+                    newKey = newKey.replace(".","_")
+                    self.logger.error("KEY is "+str(newKey))
+                    properties[newKey] = value
+            elif key == "_time":
+                timestamp = int(float(value) * 1000)
+            elif not key.startswith("_") and key != "punct" and not key.startswith("date_"):
+                if value[0] != "_" and len(value) < 256:
+                    dimensions[key.replace(".", "_")] = value
+                    
+    eventDict = {
+        'category': 'USER_DEFINED',
+        'dimensions': dimensions,
+        'properties': properties,
+        'timestamp': timestamp,
+        'eventType': eventType,
+    }
+    
+    payload.append(eventDict)
+    
+    event_payload = json.dumps(eventDict)
+    #self.logger.error(event_payload)
+    
+
+
+def send_payload(payload, target_url, token):
+    body = BytesIO()
+    with gzip.GzipFile(fileobj=body, mode="w") as fd:
+        fd.write(json.dumps(payload).encode("utf-8"))
+    body.seek(0)
+
+    resp = requests.post(
+        target_url,
+        headers={"X-SF-TOKEN": token, "Content-Encoding": "gzip", "Content-Type": "application/json"},
+        data=body.read(),
+    )
+    return resp
+
+dispatch(ToSFXCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/signalfx-forwarder-app/bin/tosfxevents.py
+++ b/signalfx-forwarder-app/bin/tosfxevents.py
@@ -1,4 +1,3 @@
-#pylint: min-similarity-lines=100
 import gzip
 import json
 import os

--- a/signalfx-forwarder-app/bin/tosfxevents.py
+++ b/signalfx-forwarder-app/bin/tosfxevents.py
@@ -1,4 +1,4 @@
-# pylint: skip-file
+#pylint:disable=broad-except
 import gzip
 import json
 import os
@@ -29,10 +29,12 @@ class ToSFXEventsCommand(EventingCommand):
 
     ## Description
 
-    One or more datapoints are generated for each input event's field(s) of the
-    form `gauge_*`, `counter_*` or `cumulative_counter_*`.  The metric name in
-    SignalFx will be the `*` part of the field name.  Any additional fields on
-    the event will be attached as dimensions to the generated datapoints.
+    One or more events are generated for each input event.  If there is a field
+    called event_* the event_type will be set to the value of the field. 
+    Fields beginning with property_ are stripped of their property_ and become 
+    properties on the event.
+    Any additional fields on the event will be attached as dimensions
+    to the generated event.
 
     """
 
@@ -131,7 +133,6 @@ def compose_ingest_url(ingest_base_url, ev_endpoint):
 
 def add_event_to_payload(self, event, payload):
 
-    eventDict = dict()
     dimensions = dict()
     properties = dict()
     timestamp = None
@@ -139,7 +140,6 @@ def add_event_to_payload(self, event, payload):
 
 
     for key, value in event.items():
-        self.logger.error("key is "+str(key) + " value is "+str(value))
         if value != "":
             if key.startswith("event_"):
                 eventType = value

--- a/signalfx-forwarder-app/bin/tosfxevents.py
+++ b/signalfx-forwarder-app/bin/tosfxevents.py
@@ -1,4 +1,4 @@
-#pylint:disable=broad-except
+#pylint:disable=duplicate-code
 import gzip
 import json
 import os
@@ -30,8 +30,8 @@ class ToSFXEventsCommand(EventingCommand):
     ## Description
 
     One or more events are generated for each input event.  If there is a field
-    called event_* the event_type will be set to the value of the field. 
-    Fields beginning with property_ are stripped of their property_ and become 
+    called event_* the event_type will be set to the value of the field.
+    Fields beginning with property_ are stripped of their property_ and become
     properties on the event.
     Any additional fields on the event will be attached as dimensions
     to the generated event.
@@ -127,7 +127,7 @@ def send_payload(payload, target_url, token):
         data=body.read(),
     )
     return resp
-    
+
 def compose_ingest_url(ingest_base_url, ev_endpoint):
     return ingest_base_url.rstrip("/") + ev_endpoint
 
@@ -136,36 +136,36 @@ def add_event_to_payload(self, event, payload):
     dimensions = dict()
     properties = dict()
     timestamp = None
-    eventType = None
+    event_type = None
 
 
     for key, value in event.items():
         if value != "":
             if key.startswith("event_"):
-                eventType = value
+                event_type = value
             elif key.startswith("property_"):
                 if value[0] != "_" and len(value) < 256:
-                    newKey = key.replace("property_", "")
-                    newKey = newKey.replace(".", "_")
-                    self.logger.error("KEY is "+str(newKey))
-                    properties[newKey] = value
+                    new_key = key.replace("property_", "")
+                    new_key = new_key.replace(".", "_")
+                    self.logger.error("KEY is "+str(new_key))
+                    properties[new_key] = value
             elif key == "_time":
                 timestamp = int(float(value) * 1000)
             elif not key.startswith("_") and key != "punct" and not key.startswith("date_"):
                 if value[0] != "_" and len(value) < 256:
                     dimensions[key.replace(".", "_")] = value
-           
-    eventDict = {
+
+    event_dict = {
         'category': 'USER_DEFINED',
         'dimensions': dimensions,
         'properties': properties,
         'timestamp': timestamp,
-        'eventType': eventType,
+        'eventType': event_type,
     }
 
-    payload.append(eventDict)
+    payload.append(event_dict)
 
-    event_payload = json.dumps(eventDict)
+    event_payload = json.dumps(event_dict)
     self.logger.error(event_payload)
 
 dispatch(ToSFXEventsCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/signalfx-forwarder-app/bin/tosfxevents.py
+++ b/signalfx-forwarder-app/bin/tosfxevents.py
@@ -1,4 +1,4 @@
-#pylint:disable=duplicate-code
+#pylint: min-similarity-lines=100
 import gzip
 import json
 import os

--- a/signalfx-forwarder-app/bin/tosfxevents.py
+++ b/signalfx-forwarder-app/bin/tosfxevents.py
@@ -21,11 +21,11 @@ import requests  # isort:skip
 
 
 @Configuration()
-class EventToSFXCommand(EventingCommand):
+class ToSFXEventsCommand(EventingCommand):
     """
     ## Syntax
 
-    <command> | eventstosfx
+    <command> | tosfxevents
 
     ## Description
 
@@ -168,4 +168,4 @@ def add_event_to_payload(self, event, payload):
     event_payload = json.dumps(eventDict)
     self.logger.error(event_payload)
 
-dispatch(EventToSFXCommand, sys.argv, sys.stdin, sys.stdout, __name__)
+dispatch(ToSFXEventsCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/signalfx-forwarder-app/default/app.conf
+++ b/signalfx-forwarder-app/default/app.conf
@@ -13,7 +13,7 @@ label = signalfx-forwarder
 [launcher]
 author = Splunk
 description = Forward data to SignalFx via a custom search command
-version = 2.0.1
+version = 2.0.2
 
 [package]
 id = signalfx-forwarder-app

--- a/signalfx-forwarder-app/default/commands.conf
+++ b/signalfx-forwarder-app/default/commands.conf
@@ -1,3 +1,7 @@
 [tosfx]
 filename = tosfx.py
 chunked = true
+
+[eventstosfx]
+filename = eventstosfx.py
+chunked = true

--- a/signalfx-forwarder-app/default/commands.conf
+++ b/signalfx-forwarder-app/default/commands.conf
@@ -2,6 +2,6 @@
 filename = tosfx.py
 chunked = true
 
-[eventstosfx]
-filename = eventstosfx.py
+[tosfxevents]
+filename = tosfxevents.py
 chunked = true

--- a/signalfx-forwarder-app/metadata/default.meta
+++ b/signalfx-forwarder-app/metadata/default.meta
@@ -14,6 +14,10 @@ access = read : [ * ], write: [ admin ]
 access = read : [ admin ], write : [ admin ]
 export = system
 
+[commands/eventstosfx]
+access = read : [ admin ], write : [ admin ]
+export = system
+
 [passwords/credential%3Asfx_ingest_commands%3Aaccess_token%3A]
 owner = admin
 export = none

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,15 +1,11 @@
-FROM python:3.6
+FROM python:3.8
 
 RUN curl -fsSL get.docker.com -o /tmp/get-docker.sh && \
     sh /tmp/get-docker.sh
 
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
-
-COPY tests/requirements.txt /tmp/tests/requirements.txt
-RUN pip install -r /tmp/tests/requirements.txt
-
 COPY ./ /code
 WORKDIR /code
+
+RUN pip install -r /code/tests/requirements.txt
 
 CMD pytest -n auto --verbose tests/splunk_test.py

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -11,7 +11,13 @@ def has_all_dims(dp, dims):
     """
     Tests if `dims`'s are all in a certain datapoint or event
     """
-    return dims <= dp.dimensions
+    return dims == dp['dimensions']
+
+def has_all_props(ev, props):
+    """
+    Tests if `props`'s are all in a certain event
+    """
+    return props == ev['properties']
 
 
 def has_no_datapoint(fake_services, metric=None, dimensions=None, value=None, metric_type=None):
@@ -50,6 +56,36 @@ def has_datapoint(
             return True
     return False
 
+def has_no_event(fake_services, category=None, properties=None, dimensions=None, event_type=None):
+    """
+    Returns True is there are no events matching the given parameters
+    """
+    return not has_event(fake_services, category, properties, dimensions, event_type, count=1)
+
+
+def has_event(
+    fake_services, category=None, properties=None, dimensions=None, event_type=None, count=1
+):
+    """
+    Returns True if there is a event seen in the fake_services backend that
+    has the given attributes.  If a property is not specified it will not be
+    considered.  Dimensions, if provided, will be tested as a subset of total
+    set of dimensions on the datapoint and not the complete set.
+    """
+    found = 0
+    for ev in fake_services.events:
+        if category and ev.get("category") != category:
+            continue
+        if dimensions and not has_all_dims(ev, dimensions):
+            continue
+        if properties and not has_all_props(ev, properties):
+            continue
+        if event_type and ev.get("eventType") != event_type:
+            continue
+        found += 1
+        if found >= count:
+            return True
+    return False
 
 def container_cmd_exit_0(container, command, **kwargs):
     """

--- a/tests/splunk-docker/install-app.sh
+++ b/tests/splunk-docker/install-app.sh
@@ -11,6 +11,9 @@ splunk list user -auth admin:testing123
 
 splunk install app ${SCRIPT_DIR}/signalfx-forwarder-*.tar.gz
 
+# set low so it works most of the time - I hit errors at default of 5000
+splunk set minfreemb 100
+
 curl -k  https://admin:testing123@localhost:8089/servicesNS/nobody/signalfx-forwarder-app/storage/collections/data/sfx_ingest_config -XPOST -H'Content-Type: application/json' -d "$(printf '{"ingest_url": "%s", "access_token": "testing123"}' "$INGEST_HOST")"
 
 splunk restart

--- a/tests/splunk_test.py
+++ b/tests/splunk_test.py
@@ -83,9 +83,9 @@ def test_signalfx_forwarder_app(splunk_version):
                 p(has_datapoint, backend, metric="max_age", metric_type="cumulative_counter", has_timestamp=False)
             )
 
-            # test eventstosfx query with time
+            # test tosfxevents query with time
             cmd = (
-                "search '| makeresults | eval event_sfx_event=\"custom\", message=\"This is a test event for emulating a search\", stack=\"stacktest\", value=\"1234\" | eventstosfx'"
+                "search '| makeresults | eval event_sfx_event=\"custom\", message=\"This is a test event for emulating a search\", stack=\"stacktest\", value=\"1234\" | tosfxevents'"
             )
             code, output = run_splunk_cmd(cont, cmd)
             assert code == 0, output.decode("utf-8")


### PR DESCRIPTION
This PR adds the ability to forward SPL events as SignalFX events (as opposed to the existing metrics tosfx command).
Also added unit tests for it and a fake handler for /events EP in SFX.
Cleaned up some of the tests file to make the unit testing to work and added instructions for unit testing (thanks Jeffrey Cheng) to the README
Note that eventstosfx has been skipped from pylint in circleci tests because it does dup0licate some tosfx code.
I did try to refactor to a base class for both but the its limiting because we are already using the Splunk base classes so not sure it can be done.
circleci tests all passed on this fork and pytest unit testing also passed