### PR TITLE
Fix appinspect failures

### DIFF
--- a/signalfx-forwarder-app/default/app.conf
+++ b/signalfx-forwarder-app/default/app.conf
@@ -18,3 +18,7 @@ version = 2.1.1
 [package]
 id = signalfx-forwarder-app
 check_for_updates = true
+
+[triggers]
+reload.sfx = simple
+reload.logging = simple

--- a/signalfx-forwarder-app/default/data/ui/views/configuration.xml
+++ b/signalfx-forwarder-app/default/data/ui/views/configuration.xml
@@ -1,4 +1,4 @@
-<dashboard script="configuration.js" stylesheet="configuration.css" hideFooter="true" hideEdit="true">
+<dashboard script="configuration.js" stylesheet="configuration.css" hideFooter="true" hideEdit="true" version="1.1">
   <label>Configuration</label>
   <row>
     <panel>

--- a/signalfx-forwarder-app/default/data/ui/views/welcome.xml
+++ b/signalfx-forwarder-app/default/data/ui/views/welcome.xml
@@ -1,4 +1,4 @@
-<dashboard>
+<dashboard version="1.1">
   <label>Welcome</label>
   <row>
     <panel>


### PR DESCRIPTION
FIxes appinspect failures based on automatic recommendations:
```
        FAILURE: Change the version attribute in the root node of your 
            Simple XML dashboard default/data/ui/views/configuration.xml to 
            `<version=1.1>`. Earlier dashboard versions introduce security 
            vulnerabilities into your apps and are not permitted in Splunk Cloud 
            File: default/data/ui/views/configuration.xml 
        FAILURE: Change the version attribute in the root node of your 
            Simple XML dashboard default/data/ui/views/welcome.xml to 
            `<version=1.1>`. Earlier dashboard versions introduce security 
            vulnerabilities into your apps and are not permitted in Splunk Cloud 
            File: default/data/ui/views/welcome.xml 
        FAILURE: Custom conf file sfx.conf does not have a reload 
            trigger in app.conf. Without a reload trigger the app will request a 
            restart on any change to the conf file, which may be a negative 
            experience for end-users. 
        FAILURE: Custom conf file logging.conf does not have a reload 
            trigger in app.conf. Without a reload trigger the app will request a 
            restart on any change to the conf file, which may be a negative 
            experience for end-users. 
```